### PR TITLE
hash alg identifiers and MTI hash alg 

### DIFF
--- a/draft-ietf-oauth-jwk-thumbprint-uri.xml
+++ b/draft-ietf-oauth-jwk-thumbprint-uri.xml
@@ -102,7 +102,8 @@
 	</list>
       </t>
       <t>
-	The prefix is followed by a hash algorithm identifier and a JWK Thumbprint value, 
+	To make it explicit in a URI which hash algorithm is used, 
+  the prefix is followed by a hash algorithm identifier and a JWK Thumbprint value, 
   each separated by a colon character to form a URI representing a JWK Thumbprint.
       </t>
     </section>
@@ -298,6 +299,9 @@
         <list style='symbols'>
           <t>
             Added security considerations about multiple public keys coresponding to the same private key.
+            Added hash algorithm identifier after the JWK thumbprint URI prefix to make it explicit in a URI which hash algorithm is used.
+            Added reference to a registry for hash algorithm identifiers.
+            Added SHA-256 as a mandatory to implement hash algorithm to promote interoperability.
 	  </t>
         </list>
       </t>

--- a/draft-ietf-oauth-jwk-thumbprint-uri.xml
+++ b/draft-ietf-oauth-jwk-thumbprint-uri.xml
@@ -51,8 +51,8 @@
 
     <abstract>
       <t>
-	This specification registers a kind of URI that represents
-	a JSON Web Key (JWK) Thumbprint value.
+	This specification registers a kind of URI that represents 
+  a JSON Web Key (JWK) Thumbprint value.
 	JWK Thumbprints are defined in RFC 7638.
 	This enables JWK Thumbprints to be used,
 	for instance, as key identifiers in contexts requiring URIs.
@@ -103,19 +103,23 @@
       </t>
       <t>
 	The prefix is followed by a hash algorithm identifier and a JWK Thumbprint value, 
-  separated by the colon to form a URI representing a JWK Thumbprint.
+  each separated by a colon character to form a URI representing a JWK Thumbprint.
       </t>
+    </section>
 
       <section anchor="HashAlgorithms" title="Hash Algorithms Identifier">
   <t>
-  Hash algorithm identifier used in JWK Thumbprint URIs are strings 
+  Hash algorithm identifiers used in JWK Thumbprint URIs are strings 
   registered in the IANA "Named Information Hash Algorithm Registry" <xref target="IANA.Hash.Algorithms"/>.
   </t>
+    </section>
 
   <section anchor="MTI" title="Mandatory to Implement Hash Algorithm">
 	<t>
-	  Mandatory to implement Hash Algorithm is SHA-256.
+	  To promote interoperability among implementations,
+    mandatory to implement hash algorithm is SHA-256.
 	</t>
+    </section>
 
       <section anchor="Example" title="Example JWK Thumbprint URI">
 	<t>

--- a/draft-ietf-oauth-jwk-thumbprint-uri.xml
+++ b/draft-ietf-oauth-jwk-thumbprint-uri.xml
@@ -102,9 +102,20 @@
 	</list>
       </t>
       <t>
-	The prefix is followed by a colon and a JWK Thumbprint value to form
-	a URI representing a JWK Thumbprint.
+	The prefix is followed by a hash algorithm identifier and a JWK Thumbprint value, 
+  separated by the colon to form a URI representing a JWK Thumbprint.
       </t>
+
+      <section anchor="HashAlgorithms" title="Hash Algorithms Identifier">
+  <t>
+  Hash algorithm identifier used in JWK Thumbprint URIs are strings 
+  registered in the IANA "Named Information Hash Algorithm Registry" <xref target="IANA.Hash.Algorithms"/>.
+  </t>
+
+  <section anchor="MTI" title="Mandatory to Implement Hash Algorithm">
+	<t>
+	  Mandatory to implement Hash Algorithm is SHA-256.
+	</t>
 
       <section anchor="Example" title="Example JWK Thumbprint URI">
 	<t>
@@ -115,10 +126,10 @@
 ]]></artwork></figure>
 
 	<t>
-	  A complete JWK Thumbprint URI using the above JWK Thumbprint is:
+	  A complete JWK Thumbprint URI using the above JWK Thumbprint and SHA-256 hash algorithm is:
 	</t>
 	<figure><artwork><![CDATA[
-  urn:ietf:params:oauth:jwk-thumbprint:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs
+  urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs
 ]]></artwork></figure>
       </section>
 
@@ -184,6 +195,16 @@
       <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7517.xml' ?>
       <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7519.xml' ?>
       <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.6755.xml' ?>
+
+      <reference anchor="IANA.Hash.Algorithms" target="https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg">
+        <front>
+          <title>Named Information Hash Algorithm Registry</title>
+          <author>
+           <organization>IANA</organization>
+          </author>
+          <date/>
+        </front>
+      </reference>
 
       <reference anchor="SIOPv2" target="https://openid.net/specs/openid-connect-self-issued-v2-1_0.html">
         <front>

--- a/draft-ietf-oauth-jwk-thumbprint-uri.xml
+++ b/draft-ietf-oauth-jwk-thumbprint-uri.xml
@@ -138,7 +138,6 @@
 ]]></artwork></figure>
       </section>
 
-    </section>
 
     <section anchor="Security" title="Security Considerations">
       <t>


### PR DESCRIPTION
Addressing comments by introducing 
- hash alg identifier following the prefix
- mandatory to implement hash
- reference to a registry with hash alg identifiers